### PR TITLE
Improve node category organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,25 @@ A collection of ComfyUI custom nodes to handle diverse camera projections (pinho
 * ### Reprojection Nodes
 
   * `ReprojectImage`, `ReprojectDepth`, `OutpaintAnyProjection`
+
+* ### Matrix Nodes
+
   * `TransformToMatrix`, `TransformToMatrixManual`
 
 * ### Depth Nodes
 
   * `DepthEstimatorNode`, `DepthToImageNode`, `ZDepthToRayDepthNode`
-  * `CombineDepthsNode`, `DepthRenormalizer`
+  * `CombineDepthsNode`, `DepthRenormalizer`, `FisheyeDepthEstimator`
 
 * ### Point Cloud Nodes
 
-  * `DepthToPointCloud`, `TransformPointCloud`, `ProjectPointCloud`
-  * `PointCloudUnion`, `PointCloudCleaner`, `LoadPointCloud`, `SavePointCloud`
+  * `DepthToPointCloud`, `TransformPointCloud`, `ProjectPointCloud`, `PointCloudUnion`
+  * `PointCloudCleaner`, `LoadPointCloud`, `SavePointCloud`, `ProjectAndClean`
+
+* ### Trajectory Nodes
+
   * `CameraMotionNode`, `CameraInterpolationNode`, `CameraTrajectoryNode`
+  * `SaveTrajectory`, `LoadTrajectory`, `PointcloudTrajectoryEnricher`
 
 ---
 

--- a/complex_nodes.py
+++ b/complex_nodes.py
@@ -64,7 +64,7 @@ class FisheyeDepthEstimator:
     RETURN_TYPES = ("TENSOR","MASK")
     RETURN_NAMES = ("depthmap","mask")
     FUNCTION = "estimate_fisheye_depth"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def estimate_fisheye_depth(
         self,
@@ -241,7 +241,7 @@ class PointcloudTrajectoryEnricher:
     RETURN_TYPES = ("TENSOR","IMAGE","TENSOR")
     RETURN_NAMES = ("enriched_pointcloud","debug_image","debug_depth")
     FUNCTION = "enrich_trajectory"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/Trajectory"
 
     def enrich_trajectory(
         self,

--- a/metric_depth_nodes.py
+++ b/metric_depth_nodes.py
@@ -41,7 +41,7 @@ class DepthEstimatorNode:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("depth tensor",)
     FUNCTION = "estimate_depth"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def estimate_depth(
         self,
@@ -110,7 +110,7 @@ class DepthToImageNode:
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ("depth image",)
     FUNCTION = "depth_to_image"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def depth_to_image(
         self,
@@ -158,7 +158,7 @@ class ZDepthToRayDepthNode:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("ray depth",)
     FUNCTION = "depth_to_ray_depth"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def depth_to_ray_depth(
         self,
@@ -229,7 +229,7 @@ class CombineDepthsNode:
     RETURN_TYPES = ("TENSOR","MASK")
     RETURN_NAMES = ("combined_depth","combined_mask")
     FUNCTION = "combine_depths"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def combine_depths(
         self,
@@ -358,7 +358,7 @@ class DepthRenormalizer:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("depth tensor",)
     FUNCTION = "renormalize_depth"
-    CATEGORY = "Camera/depth"
+    CATEGORY = "Camera/Depth"
 
     def renormalize_depth(
         self,

--- a/pointcloud_nodes.py
+++ b/pointcloud_nodes.py
@@ -167,7 +167,7 @@ class DepthToPointCloud:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("pointcloud",)
     FUNCTION = "depth_to_pointcloud"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
 
     def depth_to_pointcloud(
         self,
@@ -273,7 +273,7 @@ class TransformPointCloud:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("transformed pointcloud",)
     FUNCTION = "transform_pointcloud"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
     
     def transform_pointcloud(
         self,
@@ -321,7 +321,7 @@ class ProjectPointCloud:
     RETURN_TYPES = ("IMAGE", "MASK", "TENSOR")
     RETURN_NAMES = ("image", "mask", "depth")
     FUNCTION = "project_pointcloud"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
 
     def project_pointcloud(
         self,
@@ -456,7 +456,7 @@ class PointCloudUnion:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES =("merged pointcloud",) 
     FUNCTION = "union_pointclouds"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
 
     def union_pointclouds(
         self,
@@ -492,7 +492,7 @@ class LoadPointCloud:
             }
         }
 
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("loaded pointcloud",)
     FUNCTION = "load_pointcloud"
@@ -590,7 +590,7 @@ class SavePointCloud:
     RETURN_TYPES = ()
     FUNCTION     = "save_pointcloud"
     OUTPUT_NODE  = True
-    CATEGORY     = "Camera/pointcloud"
+    CATEGORY     = "Camera/PointCloud"
     DESCRIPTION  = "Saves the input point cloud to your ComfyUI output directory as .ply or .npy."
 
     def save_pointcloud(self, pointcloud: torch.Tensor, filename_prefix: str, save_as: str = "ply"):
@@ -681,7 +681,7 @@ class CameraMotionNode:
     RETURN_TYPES = ("IMAGE", "MASK")
     RETURN_NAMES = ("motion_frames", "mask_frames")
     FUNCTION      = "generate_motion_frames"
-    CATEGORY      = "Camera/pointcloud"
+    CATEGORY      = "Camera/Trajectory"
 
     def generate_motion_frames(
         self,
@@ -764,7 +764,7 @@ class CameraInterpolationNode:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("trajectory",)
     FUNCTION = "interpolate"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/Trajectory"
 
     def interpolate(
         self,
@@ -799,7 +799,7 @@ class CameraTrajectoryNode:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("trajectory",)
     FUNCTION = "build_trajectory"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/Trajectory"
 
     def build_trajectory(
         self,
@@ -939,7 +939,7 @@ class PointCloudCleaner:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("cleaned_pointcloud",)
     FUNCTION = "clean_pointcloud"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
 
     def clean_pointcloud(
         self,
@@ -1015,7 +1015,7 @@ class ProjectAndClean:
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("cleaned_pointcloud",)
     FUNCTION = "project_and_clean"
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/PointCloud"
 
     def project_and_clean(
         self,
@@ -1129,7 +1129,7 @@ class SaveTrajectory:
     RETURN_TYPES = ()
     FUNCTION = "save_trajectory"
     OUTPUT_NODE = True
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/Trajectory"
     DESCRIPTION = "Saves the input trajectory tensor (N,4,4) to your ComfyUI output directory as .npy."
 
     def save_trajectory(self, trajectory: torch.Tensor, filename_prefix: str):
@@ -1179,7 +1179,7 @@ class LoadTrajectory:
             }
         }
 
-    CATEGORY = "Camera/pointcloud"
+    CATEGORY = "Camera/Trajectory"
     RETURN_TYPES = ("TENSOR",)
     RETURN_NAMES = ("loaded_trajectory",)
     FUNCTION = "load_trajectory"

--- a/reprojection_nodes.py
+++ b/reprojection_nodes.py
@@ -148,7 +148,7 @@ class ReprojectImage:
     RETURN_TYPES: Tuple[str, str] = ("IMAGE", "MASK")
     RETURN_NAMES = ("reprojected image", "reprojected mask")
     FUNCTION: str = "reproject_image"
-    CATEGORY: str = "Camera/reproject"
+    CATEGORY: str = "Camera/Reprojection"
 
     def reproject_image(
         self,
@@ -303,7 +303,7 @@ class TransformToMatrix:
     RETURN_TYPES: Tuple[str] = ("MAT_4X4",)
     RETURN_NAMES = ("transformation matrix",)
     FUNCTION: str = "generate_matrix"
-    CATEGORY: str = "Camera/reproject"
+    CATEGORY: str = "Camera/Matrix"
 
     def generate_matrix(
         self,
@@ -392,7 +392,7 @@ class TransformToMatrixManual:
     RETURN_TYPES: Tuple[str] = ("MAT_4X4",)
     RETURN_NAMES = ("transformation matrix",)
     FUNCTION: str = "generate_matrix"
-    CATEGORY: str = "Camera/reproject"
+    CATEGORY: str = "Camera/Matrix"
 
     def generate_matrix(
         self,
@@ -444,7 +444,7 @@ class ReprojectDepth:
     RETURN_TYPES: Tuple[str, str] = ("TENSOR", "MASK")
     RETURN_NAMES = ("reprojected_depth", "reprojected_mask")
     FUNCTION: str = "reproject_depth"
-    CATEGORY: str = "Camera/reproject"
+    CATEGORY: str = "Camera/Reprojection"
 
     def reproject_depth(
         self,


### PR DESCRIPTION
## Summary
- reorganize node categories for clearer grouping
- split matrix and trajectory related nodes into dedicated groups
- update README with new category layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68488fabcc048333b089c8e3f3718051